### PR TITLE
Feature/add subaccounts and splits

### DIFF
--- a/admin/class-paystack-give-admin.php
+++ b/admin/class-paystack-give-admin.php
@@ -207,6 +207,20 @@ class Paystack_Give_Admin
                         'row_classes' => 'give-paystack-test-public-key',
                     ],
                     [
+                        'name'        => esc_html__( 'Test Subaccount Code', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Test Subaccount Code', 'paystack-give' ),
+                        'id'          => 'paystack_test_subaccount_code',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-test-subaccount-code',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Test Split Code', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Test Split Code', 'paystack-give' ),
+                        'id'          => 'paystack_test_split_code',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-test-split-code',
+                    ],
+                    [
                         'name'        => esc_html__( 'Live Secret Key', 'paystack-give' ),
                         'desc'        => esc_html__( 'Enter your Paystack Live Secret Key', 'paystack-give' ),
                         'id'          => 'paystack_live_secret_key',
@@ -219,6 +233,20 @@ class Paystack_Give_Admin
                         'id'          => 'paystack_live_public_key',
                         'type'        => 'text',
                         'row_classes' => 'give-paystack-live-public-key',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Live Subaccount Code', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Live Subaccount Code', 'paystack-give' ),
+                        'id'          => 'paystack_live_subaccount_code',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-live-subaccount-code',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Live Split Code', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Live Split Code', 'paystack-give' ),
+                        'id'          => 'paystack_live_split_code',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-live-split-code',
                     ],
                     [
                         'name'    => esc_html__( 'Billing Details', 'paystack-give' ),

--- a/includes/class-paystack-give.php
+++ b/includes/class-paystack-give.php
@@ -389,14 +389,18 @@ class Paystack_Give
                     give_send_back_to_checkout('?payment-mode=' . $purchase_data['post_data']['give-gateway'] . "&message=-some weird error happened-&payment_id=" . json_encode($payment));
                 } else {
 
-                    //Begin processing payment
+                    // Begin processing payment
 
                     if (give_is_test_mode()) {
                         $public_key = give_get_option('paystack_test_public_key');
                         $secret_key = give_get_option('paystack_test_secret_key');
+                        $subaccount_code = give_get_option('paystack_test_subaccount_code');
+                        $split_code = give_get_option('paystack_test_split_code');
                     } else {
                         $public_key = give_get_option('paystack_live_public_key');
                         $secret_key = give_get_option('paystack_live_secret_key');
+                        $subaccount_code = give_get_option('paystack_live_subaccount_code');
+                        $split_code = give_get_option('paystack_live_split_code');
                     }
 
                     $ref = $purchase_data['purchase_key']; // . '-' . time() . '-' . preg_replace("/[^0-9a-z_]/i", "_", $purchase_data['user_email']);
@@ -414,6 +418,8 @@ class Paystack_Give
                     $fields = [
                         'email' => $payment_data['user_email'],
                         'amount' => $payment_data['price'] * 100,
+                        'subaccount' => $subaccount_code,
+                        'split_code' => $split_code,
                         'reference' => $ref,
                         'callback_url' => $verify_url,
                         'currency' => $currency,


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain changes

- Add support for subaccounts and split codes to enable platform(s) to charge a maintenance fee for running crowdfunding/donation exercises on their platform using GiveWP and Paystack.
- Add fields in the WP admin section to input Test and Live Subaccount/Split codes, right below the default Test and Live Secret/Public Keys, through the plugin _admin_ folder.
- Subaccounts are created in Paystack Dashboard to help the platform charge a percentage of raised donations as a maintenance fee while automatically remitting the balance to a fundraiser. Codes related to certain subaccounts after creation can be copied and pasted into the new fields to be utilized.
- Add subaccount/split codes to the Initialize Transaction API endpoint; in the _includes_ folder, to process payment sessions.

#### Other comments?
Tested both Test and Live payment sessions and got successful payments and percentage splits on transactions on my platform which I am working on.